### PR TITLE
Typo in Travis CI badge fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-# Api Connect Client [![Build Status](https://travis-ci.org/cffiebig/api-connect-client.svg?branch=master)](https://travis-ci.org/cffiebigc/api-connect-client) [![Gem Version](https://badge.fury.io/rb/api_connect_client.svg)](https://badge.fury.io/rb/api_connect_client)
+# Api Connect Client [![Build Status](https://travis-ci.org/cffiebigc/api-connect-client.svg?branch=master)](https://travis-ci.org/cffiebigc/api-connect-client) [![Gem Version](https://badge.fury.io/rb/api_connect_client.svg)](https://badge.fury.io/rb/api_connect_client)
 
 This gem is used to interact with the [Developer Portal REST APIs](https://www.ibm.com/support/knowledgecenter/en/SSFS6T/com.ibm.apic.apirest.doc/dev_portal_apis.html)
  to perform some of the operations that are normally carried out in the Developer Portal UI.


### PR DESCRIPTION
In my previous PR (#2), the SVG Travis Ci badge was pointing to cffiebig account, and should be pointing to cffiebigc.

This PR fixes that issue, to show properly the Travis CI badge.